### PR TITLE
feat: Add technical indicators (Moving Average and Bollinger Bands)

### DIFF
--- a/stock_data.py
+++ b/stock_data.py
@@ -99,3 +99,37 @@ class StockDataManager:
             return not data.empty
         except:
             return False
+    
+    def calculate_moving_average(self, data: pd.DataFrame, window: int = 20) -> pd.Series:
+        """
+        移動平均線を計算する
+        
+        Args:
+            data: 株価データ
+            window: 移動平均の期間（デフォルト: 20日）
+        
+        Returns:
+            pd.Series: 移動平均データ
+        """
+        return data['Close'].rolling(window=window).mean()
+    
+    def calculate_bollinger_bands(self, data: pd.DataFrame, window: int = 20, std_dev: int = 2) -> Dict:
+        """
+        ボリンジャーバンドを計算する
+        
+        Args:
+            data: 株価データ
+            window: 移動平均の期間（デフォルト: 20日）
+            std_dev: 標準偏差の倍数（デフォルト: 2）
+        
+        Returns:
+            Dict: ボリンジャーバンドデータ（upper, lower, middle）
+        """
+        sma = data['Close'].rolling(window=window).mean()
+        std = data['Close'].rolling(window=window).std()
+        
+        return {
+            'upper': sma + (std * std_dev),
+            'lower': sma - (std * std_dev),
+            'middle': sma
+        }


### PR DESCRIPTION
## Summary

Added two technical indicators to the stock analyzer application:

- ✅ **Moving Average (移動平均線)**: Configurable period (default: 20 days)
- ✅ **Bollinger Bands (ボリンジャーバンド)**: Configurable period and standard deviation (defaults: 20 days, 2σ)

## Features

- Added calculation methods to StockDataManager class
- New UI section with checkboxes and parameter controls
- Multi-symbol support for all technical indicators
- Proper styling with dashed/dotted lines and transparency
- Shaded area between Bollinger Band boundaries

## Implementation

- `stock_data.py`: Added `calculate_moving_average()` and `calculate_bollinger_bands()` methods
- `web_app.py`: Added UI controls and updated chart callback logic

## Test Plan

- [ ] Test moving average with different periods (10, 20, 50 days)
- [ ] Test Bollinger Bands with different parameters
- [ ] Test multi-symbol display with technical indicators
- [ ] Verify indicator toggling on/off functionality
- [ ] Test with various time periods (1d, 1mo, 1y, etc.)

Closes #8

Generated with [Claude Code](https://claude.ai/code)